### PR TITLE
Feature/email quota summary list

### DIFF
--- a/disk_usage.txt
+++ b/disk_usage.txt
@@ -1,1 +1,1 @@
-519936	/home/jalakdev/www/crm
+603364	/home/jalakdev/www/crm

--- a/resources/views/email/quota/detail.blade.php
+++ b/resources/views/email/quota/detail.blade.php
@@ -1,0 +1,169 @@
+@extends('layouts.master')
+@section('title')
+    Email Quota Usage Analytics {{ $monthName }} | {{ config('app.name') }}
+@endsection
+
+@section('content')
+<div class="right_col" role="main">
+    <section class="content">
+        <div class="container-fluid">
+            <div class="row clearfix">
+                <div class="x_panel tile">
+                    <div class="panel-heading">
+                        <a href="{{ url('email/quota/usage') }}" class="btn btn-primary pull-right">
+                            <i class="fa fa-arrow-left"></i> Back to Overview
+                        </a>
+                        <h2>Email Quota Usage Analytics - {{ $monthName }}</h2>
+                        <br><br>
+                    </div>
+                    <div class="x_content" style="height:120px;">
+                        <div class="row tile_count" style="display: flex; flex-wrap: nowrap;">
+                            <div class="tile_stats_count" style="flex: 1; margin: 0 5px;">
+                                <span class="count_top"><i class="fa fa-paper-plane"></i> TOTAL REQUESTS</span>
+                                <div class="count blue">
+                                    {{ number_format($quotaData['calculated_metrics']['total_requests'] ?? 0, 0, ',', '.') }}
+                                </div>
+                                <span class="count_bottom">Grand total/span>
+                            </div>
+                            <div class="tile_stats_count" style="flex: 1; margin: 0 5px;">
+                                <span class="count_top"><i class="fa fa-check-circle"></i> SUCCESSFULLY SENT</span>
+                                <div class="count green">
+                                    {{ number_format($quotaData['metrics']['sent'] ?? 0, 0, ',', '.') }}
+                                </div>
+                                <span class="count_bottom">{{ number_format($quotaData['calculated_metrics']['sent_rate'] ?? 0, 1) }}% of requests</span>
+                            </div>
+                            <div class="tile_stats_count" style="flex: 1; margin: 0 5px;">
+                                <span class="count_top"><i class="fa fa-exclamation-triangle"></i> BOUNCED</span>
+                                <div class="count red">
+                                    {{ number_format($quotaData['metrics']['bounce'] ?? 0, 0, ',', '.') }}
+                                </div>
+                                <span class="count_bottom">{{ number_format($quotaData['calculated_metrics']['bounce_rate'] ?? 0, 1) }}% of requests</span>
+                            </div>
+                            <div class="tile_stats_count" style="flex: 1; margin: 0 5px;">
+                                <span class="count_top"><i class="fa fa-times-circle"></i> DROPPED</span>
+                                <div class="count gray">
+                                    {{ number_format($quotaData['metrics']['dropped'] ?? 0, 0, ',', '.') }}
+                                </div>
+                                <span class="count_bottom">{{ number_format($quotaData['calculated_metrics']['drop_rate'] ?? 0, 1) }}% of requests</span>
+                            </div>
+                            <div class="tile_stats_count" style="flex: 1; margin: 0 5px;">
+                                <span class="count_top"><i class="fa fa-eye"></i> OPENED</span>
+                                <div class="count blue">
+                                    {{ number_format($quotaData['metrics']['open'] ?? 0, 0, ',', '.') }}
+                                </div>
+                                <span class="count_bottom">{{ number_format($quotaData['calculated_metrics']['open_rate'] ?? 0, 1) }}% open rate</span>
+                            </div>
+                            <div class="tile_stats_count" style="flex: 1; margin: 0 5px;">
+                                <span class="count_top"><i class="fa fa-mouse-pointer"></i> CLICKED</span>
+                                <div class="count green">
+                                    {{ number_format($quotaData['metrics']['click'] ?? 0, 0, ',', '.') }}
+                                </div>
+                                <span class="count_bottom">{{ number_format($quotaData['calculated_metrics']['click_rate'] ?? 0, 1) }}% click rate</span>
+                            </div>
+                            <div class="tile_stats_count" style="flex: 1; margin: 0 5px;">
+                                <span class="count_top"><i class="fa fa-user-times"></i> UNSUBSCRIBED</span>
+                                <div class="count orange">
+                                    {{ number_format($quotaData['metrics']['unsub'] ?? 0, 0, ',', '.') }}
+                                </div>
+                                <span class="count_bottom">Opted out</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            
+            
+            
+            <div class="row clearfix">
+                <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
+                    <div class="card">
+                       
+                        <div class="body">
+                            <table class="table table-bordered table-striped table-hover datatable responsive js-basic-example" id="datatable-responsive" width="100%">
+                                <thead class="bg-teal">
+                                <!-- First header row -->
+                                <tr>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 6%;">No</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 14%;">Date</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 14%;">Day of Week</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 14%;">Quota Usage</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 14%;">Quota Remaining</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 12%;">Usage %</th>
+                                    <th class="text-center align-middle" colspan="3" style="vertical-align: middle; width: 26%; border-right: 2px solid #ddd;">Sent</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 10%;">Bounced</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 10%;">Drop</th>
+                                </tr>
+                                <!-- Second header row -->
+                                <tr>
+                                    <th class="text-center align-middle" style="vertical-align: middle;">opened</th>
+                                    <th class="text-center align-middle" style="vertical-align: middle;">clicked</th>
+                                    <th class="text-center align-middle" style="vertical-align: middle; border-right: 2px solid #ddd;">unsubscribe</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @if(isset($quotaData['daily_breakdown']))
+                                    @php $counter = 1; @endphp
+                                    @foreach($quotaData['daily_breakdown'] as $date => $dayData)
+                                    <!-- First row showing Total Sent -->
+                                    <tr class="text-center bg-light">
+                                        <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">{{ $counter++ }}</td>
+                                        <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">{{ Carbon\Carbon::parse($date)->format('d M Y') }}</td>
+                                        <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">{{ Carbon\Carbon::parse($date)->format('l') }}</td>
+                                        <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">
+                                            <span class="badge {{ $dayData['requests'] > 2000 ? 'alert-danger' : ($dayData['requests'] > 1000 ? 'alert-warning' : 'alert-success') }}">
+                                                {{ number_format($dayData['quota_used'], 0, ',', '.') }}
+                                            </span>
+                                        </td>
+                                        <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">{{ number_format($dayData['quota_remaining'], 0, ',', '.') }}</td>
+                                        <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">
+                                            <div class="progress" style="height: 20px; margin: 0 auto; width: 80%;" title="Usage: {{ number_format($dayData['usage_percentage'], 2) }}% | Used: {{ number_format($dayData['quota_used'], 0, ',', '.') }} | Daily Limit: {{ number_format($dayData['daily_quota_limit'] ?? 3000, 0, ',', '.') }}">
+                                                <div class="progress-bar {{ $dayData['usage_percentage'] > 80 ? 'progress-bar-danger' : ($dayData['usage_percentage'] > 60 ? 'progress-bar-warning' : 'progress-bar-success') }}" 
+                                                     style="width: {{ $dayData['usage_percentage'] }}%">
+                                                        {{ number_format($dayData['usage_percentage'], 1) }}%
+                                                    </div>
+                                                </div>
+                                            </td>
+                                            <td colspan="3" class="text-center align-middle" style="vertical-align: middle; border-right: 2px solid #ddd;">
+                                                <strong style="font-size: 14px;">Total Sent: {{ number_format($dayData['sent'], 0, ',', '.') }}</strong>
+                                            </td>
+                                            <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">
+                                                <span class="badge {{ $dayData['bounced'] > 0 ? 'alert-danger' : 'alert-secondary' }}">
+                                                    {{ number_format($dayData['bounced'], 0, ',', '.') }}
+                                                </span>
+                                            </td>
+                                            <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">
+                                                <span class="badge alert-secondary">
+                                                    {{ number_format($dayData['dropped'], 0, ',', '.') }}
+                                                </span>
+                                            </td>
+                                        </tr>
+                                        <!-- Second row showing individual metrics -->
+                                        <tr class="text-center">
+                                            <td class="text-center align-middle" style="vertical-align: middle;">
+                                                <span class="badge {{ $dayData['opened'] > 0 ? 'alert-info' : 'alert-secondary' }}">
+                                                    {{ number_format($dayData['opened'], 0, ',', '.') }}
+                                                </span>
+                                            </td>
+                                            <td class="text-center align-middle" style="vertical-align: middle;">
+                                                <span class="badge alert-success">
+                                                    {{ number_format($dayData['clicked'], 0, ',', '.') }}
+                                                </span>
+                                            </td>
+                                            <td class="text-center align-middle" style="vertical-align: middle; border-right: 2px solid #ddd;">
+                                                <span class="badge alert-warning">
+                                                    {{ number_format($dayData['unsubscribed'], 0, ',', '.') }}
+                                                </span>
+                                            </td>
+                                        </tr>
+                                        @endforeach
+                                    @endif
+                                    </tbody>
+                                </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+@endsection

--- a/resources/views/email/quota/list.blade.php
+++ b/resources/views/email/quota/list.blade.php
@@ -1,0 +1,170 @@
+@extends('layouts.master')
+@section('title')
+    Email Quota Usage {{ $currentYear }} | {{ \App\Models\Configuration::first()->hotel_name.' '.\App\Models\Configuration::first()->app_title }}
+@endsection
+@section('content')
+
+<div class="right_col" role="main">
+    <section class="content">
+        <div class="container-fluid">
+            <div class="row clearfix">
+                <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
+                    <div class="card">
+                        <div class="header">
+                            <h2>Email Quota Usage - {{ $currentYear }}</h2>
+                            <!-- Default pagination view options -->
+                            <div class="row" style="margin-top: 10px;">
+                                <div class="col-md-6">
+                                    <div class="dataTables_length">
+                                        <label>Show 
+                                            <select name="datatable-responsive_length" class="form-control input-sm" style="display: inline-block; width: auto;">
+                                                <option value="10">10</option>
+                                                <option value="25">25</option>
+                                                <option value="50">50</option>
+                                                <option value="100">100</option>
+                                            </select> entries
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="dataTables_filter" style="text-align: right;">
+                                        <label>Search: 
+                                            <input type="search" class="form-control input-sm" placeholder="" style="display: inline-block; width: auto;">
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="row clearfix">
+                            <div class="col-lg-12">
+                            </div>
+                        </div>
+
+                        <div class="body">
+                            <table class="table table-bordered table-striped table-hover datatable responsive js-basic-example" id="datatable-responsive" width="100%">
+                                <thead class="bg-teal">
+                                <!-- First header row -->
+                                <tr>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 5%;">No</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 10%;">Month</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 12%;">Billing Period</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 12%;">Quota Usage</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 12%;">Quota Remaining</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 10%;">Usage %</th>
+                                    <th class="text-center align-middle" colspan="3" style="vertical-align: middle; width: 24%; border-right: 2px solid #ddd;">Sent</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 8%;">Bounced</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 7%;">Drop</th>
+                                    <th class="text-center align-middle" rowspan="2" style="vertical-align: middle; width: 10%;">Action</th>
+                                </tr>
+                                <!-- Second header row -->
+                                <tr>
+                                    <th class="text-center align-middle" style="vertical-align: middle;">opened</th>
+                                    <th class="text-center align-middle" style="vertical-align: middle;">clicked</th>
+                                    <th class="text-center align-middle" style="vertical-align: middle; border-right: 2px solid #ddd;">unsubscribe</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @foreach($monthlyData as $key => $data)
+                                @php
+                                    $sent = $data['metrics']['sent'] ?? 0;
+                                    $opened = $data['metrics']['open'] ?? 0;
+                                    $clicked = $data['metrics']['click'] ?? 0;
+                                    $unsubscribed = $data['metrics']['unsub'] ?? 0;
+                                @endphp
+                                <!-- First row showing Total Sent -->
+                                <tr class="text-center bg-light">
+                                    <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">{{ $key+1 }}</td>
+                                    <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">
+                                        <a href="{{ url('email/quota/usage/').'/'.$data['month'] }}" >
+                                            {{ $data['month_name'] }}
+                                        </a>
+                                    </td>
+                                    <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">{{ Carbon\Carbon::parse($data['period_start'])->format('M d') }} - {{ Carbon\Carbon::parse($data['period_end'])->format('M d') }}</td>
+                                    <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">
+                                        <span class="badge {{ $data['usage_percentage'] > 80 ? 'alert-danger' : ($data['usage_percentage'] > 60 ? 'alert-warning' : 'alert-success') }}">
+                                            {{ number_format($data['quota_used'], 0, ',', '.') }}
+                                        </span>
+                                    </td>
+                                    <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">{{ number_format($data['quota_remaining'], 0, ',', '.') }}</td>
+                                    <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">
+                                        <div class="progress" style="height: 20px; margin: 0 auto; width: 80%;" title="Usage: {{ number_format($data['usage_percentage'], 2) }}% ({{ number_format($data['quota_used'], 0, ',', '.') }} / {{ number_format($data['quota_used'] + $data['quota_remaining'], 0, ',', '.') }})">
+                                            <div class="progress-bar {{ $data['usage_percentage'] > 80 ? 'progress-bar-danger' : ($data['usage_percentage'] > 60 ? 'progress-bar-warning' : 'progress-bar-success') }}" 
+                                                 style="width: {{ $data['usage_percentage'] }}%">
+                                                {{ number_format($data['usage_percentage'], 1) }}%
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td colspan="3" class="text-center align-middle" style="vertical-align: middle; border-right: 2px solid #ddd;">
+                                        <strong style="font-size: 14px;">Total Sent: {{ number_format($sent, 0, ',', '.') }}</strong>
+                                    </td>
+                                    <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">
+                                        <span class="badge {{ ($data['metrics']['bounce'] ?? 0) > 0 ? 'alert-danger' : 'alert-secondary' }}">
+                                            {{ number_format($data['metrics']['bounce'] ?? 0, 0, ',', '.') }}
+                                        </span>
+                                    </td>
+                                    <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">
+                                        <span class="badge alert-secondary">
+                                            {{ number_format($data['metrics']['dropped'] ?? 0, 0, ',', '.') }}
+                                        </span>
+                                    </td>
+                                    <td rowspan="2" class="text-center align-middle" style="vertical-align: middle;">
+                                        <a href="{{ url('email/quota/usage/').'/'.$data['month'] }}" title="View Detailed Analytics">
+                                            <i class="fa fa-eye" style="font-size: 1.5em;"></i>
+                                        </a>
+                                    </td>
+                                </tr>
+                                <!-- Second row showing individual metrics -->
+                                <tr class="text-center">
+                                    <td class="text-center align-middle" style="vertical-align: middle;">
+                                        <span class="badge {{ $opened > 0 ? 'alert-info' : 'alert-secondary' }}">
+                                            {{ number_format($opened, 0, ',', '.') }}
+                                        </span>
+                                    </td>
+                                    <td class="text-center align-middle" style="vertical-align: middle;">
+                                        <span class="badge {{ $clicked > 0 ? 'alert-success' : 'alert-secondary' }}">
+                                            {{ number_format($clicked, 0, ',', '.') }}
+                                        </span>
+                                    </td>
+                                    <td class="text-center align-middle" style="vertical-align: middle; border-right: 2px solid #ddd;">
+                                        <span class="badge {{ $unsubscribed > 0 ? 'alert-warning' : 'alert-secondary' }}">
+                                            {{ number_format($unsubscribed, 0, ',', '.') }}
+                                        </span>
+                                    </td>
+                                </tr>
+                                @endforeach
+                                </tbody>
+                            </table>
+                            
+                            <!-- Pagination -->
+                            <div class="row" style="margin-top: 15px;">
+                                <div class="col-md-6">
+                                    <div class="dataTables_info">
+                                        Showing 1 to {{ count($monthlyData) }} of {{ count($monthlyData) }} entries
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="dataTables_paginate paging_simple_numbers" style="text-align: right;">
+                                        <ul class="pagination">
+                                            <li class="paginate_button previous disabled">
+                                                <a href="#">Previous</a>
+                                            </li>
+                                            <li class="paginate_button active">
+                                                <a href="#">1</a>
+                                            </li>
+                                            <li class="paginate_button next disabled">
+                                                <a href="#">Next</a>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+@endsection
+@section('script')
+@endsection

--- a/resources/views/layouts/_navbar.blade.php
+++ b/resources/views/layouts/_navbar.blade.php
@@ -10,15 +10,14 @@
 
             <!-- Email Quota Info -->
             <div class="email-quota-info-modern">
-                <div class="quota-badge quota-brand" title="Sharing Account">RCD-RMS</div>
-                <div class="quota-badge quota-today" title="Today ({{ now()->format('d M Y') }}) | Limit: 3.000/day">
+                <a href="{{ url('email/quota/usage') }}" class="quota-badge quota-brand" title="Sharing Account">RCD-RMS</a>
+                <span class="quota-today-no-hover" style="cursor: default" title="Today ({{ now()->format('d M Y') }}) | Limit: 3.000/day">
                     Today: <span class="quota-number">{{ number_format($quotaInfo['today_quota']['used'], 0, ',', '.') }}/{{ number_format($quotaInfo['today_quota']['remaining'], 0, ',', '.') }}</span>
-                </div>
-                <div class="quota-badge quota-period" title="Period: {{ Carbon\Carbon::parse($quotaInfo['billing_cycle']['start'])->format('d M Y') }} - {{ Carbon\Carbon::parse($quotaInfo['billing_cycle']['end'])->format('d M Y') }} | Total Limit: 150.000">
+                </span>
+                <span class="quota-period-no-hover" style="cursor: default" title="Period: {{ Carbon\Carbon::parse($quotaInfo['billing_cycle']['start'])->format('d M Y') }} - {{ Carbon\Carbon::parse($quotaInfo['billing_cycle']['end'])->format('d M Y') }} | Total Limit: 150.000">
                     Period: <span class="quota-number">{{ number_format($quotaInfo['quota_used'], 0, ',', '.') }}/{{ number_format($quotaInfo['quota_remaining'], 0, ',', '.') }}</span>
-                </div>
+                </span>
             </div>
-
 
             <ul class="nav navbar-nav navbar-right">
                 <li class="">
@@ -64,10 +63,13 @@
         box-shadow: 0 1px 3px rgba(0,0,0,0.05);
         transition: all 0.2s ease;
         cursor: pointer;
+        text-decoration: none;
     }
 
     .quota-badge:hover {
         background: #e2e8f0;
+        text-decoration: none;
+        color: #333;
     }
 
     .quota-brand {
@@ -79,6 +81,25 @@
     .quota-brand:hover {
         background: white;
         color: #3498db;
+        text-decoration: none;
+    }
+
+    .quota-today-no-hover,
+    .quota-period-no-hover {
+        background: #f1f5f9;
+        color: #333;
+        padding: 5px 10px;
+        border-radius: 999px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+        cursor: pointer;
+        text-decoration: none;
+    }
+
+    .quota-today-no-hover:hover,
+    .quota-period-no-hover:hover {
+        background: #f1f5f9;
+        color: #333;
+        text-decoration: none;
     }
 
     .quota-number {

--- a/routes/web.php
+++ b/routes/web.php
@@ -70,7 +70,11 @@ Route::get('apitest',function (){
 
 
 
-Route::get('email/quota/{month?}', function($month = null) {
+Route::get('email/quota/usage', [App\Http\Controllers\PepipostMail::class, 'quotaUsageList'])->name('email.quota.usage');
+Route::get('email/quota/usage/{month}', [App\Http\Controllers\PepipostMail::class, 'quotaUsageDetail'])->name('email.quota.usage.detail');
+
+
+Route::get('api/email/quota/{month?}', function($month = null) {
     $mail = new PepipostMail();
     return $mail->getEmailQuota($month);
 });


### PR DESCRIPTION

<img width="1656" height="785" alt="test" src="https://github.com/user-attachments/assets/287c11e1-8311-4c2d-a600-5cd015dd98c5" />
### Fitur: Email Quota Statistics

Fitur ini menambahkan halaman statistik penggunaan email Pepipost secara lengkap, dengan tampilan summary dan detail berdasarkan siklus billing bulanan.

### Ringkasan Perubahan

- Menambahkan halaman Summary Tahunan:
  - Statistik tahunan berdasarkan billing cycle per bulan (bukan kalender)
  - Ditampilkan metrik:
    - Requests (sent + bounce + drop)
    - Sent
    - Dropped
    - Bounced
    - Opened
    - Clicked
    - Unsubscribed
  - Setiap bulan dapat diklik menuju halaman detail

- Menambahkan halaman Detail Bulanan:
  - Menampilkan statistik harian dalam bulan tersebut
  - Dilengkapi analitik dan persentase:
    - Sent Rate
    - Open Rate
    - Click Rate
    - Bounce Rate
    - Drop Rate

- Perhitungan:
  - requests = sent + bounce + drop
  - sent = opened + clicked

### Tujuan

Memberikan visibilitas terhadap penggunaan kuota Pepipost dan performa pengiriman email dari bulan ke bulan secara menyeluruh, untuk membantu proses analisis dan optimasi.