### PR TITLE
Add Pepipost Quota env Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ yarn-error.log
 /.vscode
 /MYSQL_BACKUP
 storage/framework/views/*.php
+!storage/framework/views/.gitignore

--- a/app/Http/Controllers/PepipostMail.php
+++ b/app/Http/Controllers/PepipostMail.php
@@ -26,10 +26,10 @@ class PepipostMail extends Controller
 
             $quotaConfig = [
                 'period' => [
-                    'total' => 150000,  // Total quota per periode billing
+                    'total' => env('EMAIL_QUOTA_TOTAL', 150000),  // Total quota per periode billing
                 ],
                 'daily' => [
-                    'limit' => 5000     // Batas maksimum pengiriman per hari
+                    'limit' => env('EMAIL_QUOTA_DAILY_LIMIT', 5000)     // Batas maksimum pengiriman per hari
                 ]
             ];
 
@@ -246,8 +246,8 @@ class PepipostMail extends Controller
                         'month_name' => Carbon::create($currentYear, $i, 1)->format('F Y'),
                         'month_short' => Carbon::create($currentYear, $i, 1)->format('M Y'),
                         'quota_used' => $quotaData['quota_info']['quota_used'] ?? 0,
-                        'quota_remaining' => $quotaData['quota_info']['quota_remaining'] ?? 150000,
-                        'total_quota' => $quotaData['quota_info']['total_quota'] ?? 150000,
+                        'quota_remaining' => $quotaData['quota_info']['quota_remaining'] ?? env('EMAIL_QUOTA_TOTAL', 150000),
+                        'total_quota' => $quotaData['quota_info']['total_quota'] ?? env('EMAIL_QUOTA_TOTAL', 150000),
                         'usage_percentage' => $quotaData['quota_info']['quota_usage_percentage'] ?? 0,
                         'period_start' => $quotaData['period']['start'] ?? '',
                         'period_end' => $quotaData['period']['end'] ?? '',

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,12 +34,12 @@ class AppServiceProvider extends ServiceProvider
         // Get quota info from cache if available
         $quotaInfo = cache()->get('email_quota_info');
         
-        // If no cache, use default values
+        // If no cache, use default values from environment
         if (!$quotaInfo) {
             $quotaInfo = [
-                'today_quota' => ['used' => 0, 'remaining' => 5000],
+                'today_quota' => ['used' => 0, 'remaining' => env('EMAIL_QUOTA_DAILY_LIMIT', 5000)],
                 'quota_used' => 0,
-                'quota_remaining' => 150000,
+                'quota_remaining' => env('EMAIL_QUOTA_TOTAL', 150000),
                 'billing_cycle' => [
                     'start' => now()->format('Y-m-d'),
                     'end' => now()->addMonth()->format('Y-m-d')
@@ -49,6 +49,14 @@ class AppServiceProvider extends ServiceProvider
         
         // Share with views for navbar
         view()->share('quotaInfo', $quotaInfo);
+        
+        // Share email configuration
+        view()->share('emailConfig', [
+            'sharing_account' => env('EMAIL_SHARING_ACCOUNT_NAME', 'RRP-RRPTG-PS'),
+            'sharing_accounts' => explode(',', env('EMAIL_SHARING_ACCOUNTS', 'RRP-RRPTG-PS')),
+            'daily_limit' => env('EMAIL_QUOTA_DAILY_LIMIT', 5000),
+            'total_quota' => env('EMAIL_QUOTA_TOTAL', 150000)
+        ]);
         
         // Only update cache if it's older than 30 minutes
         $shouldUpdate = !cache()->has('email_quota_last_update') || 

--- a/resources/views/layouts/_navbar.blade.php
+++ b/resources/views/layouts/_navbar.blade.php
@@ -10,11 +10,11 @@
 
             <!-- Email Quota Info -->
             <div class="email-quota-info-modern">
-                <a href="{{ url('email/quota/usage') }}" class="quota-badge quota-brand" title="Sharing Account">RRP-RRPTG-PS</a>
-                <span class="quota-today-no-hover" style="cursor: default" title="Today ({{ now()->format('d M Y') }}) | Limit: 3.000/day">
+                <a href="{{ url('email/quota/usage') }}" class="quota-badge quota-brand" title="Sharing Account">{{ $emailConfig['sharing_account'] }}</a>
+                <span class="quota-today-no-hover" style="cursor: default" title="Today ({{ now()->format('d M Y') }}) | Limit: {{ number_format($emailConfig['daily_limit'], 0, ',', '.') }}/day">
                     Today: <span class="quota-number">{{ number_format($quotaInfo['today_quota']['used'], 0, ',', '.') }}/{{ number_format($quotaInfo['today_quota']['remaining'], 0, ',', '.') }}</span>
                 </span>
-                <span class="quota-period-no-hover" style="cursor: default" title="Period: {{ Carbon\Carbon::parse($quotaInfo['billing_cycle']['start'])->format('d M Y') }} - {{ Carbon\Carbon::parse($quotaInfo['billing_cycle']['end'])->format('d M Y') }} | Total Limit: 150.000">
+                <span class="quota-period-no-hover" style="cursor: default" title="Period: {{ Carbon\Carbon::parse($quotaInfo['billing_cycle']['start'])->format('d M Y') }} - {{ Carbon\Carbon::parse($quotaInfo['billing_cycle']['end'])->format('d M Y') }} | Total Limit: {{ number_format($emailConfig['total_quota'], 0, ',', '.') }}">
                     Period: <span class="quota-number">{{ number_format($quotaInfo['quota_used'], 0, ',', '.') }}/{{ number_format($quotaInfo['quota_remaining'], 0, ',', '.') }}</span>
                 </span>
             </div>


### PR DESCRIPTION
## Description
Implementasi fitur untuk membaca dan menggunakan konfigurasi quota Pepipost dari environment (`.env`), sehingga nilai quota dapat diatur tanpa harus mengubah kode.

## Changes
- **`PepipostMail.php`**  
  - Tambah pembacaan nilai quota dari `env()`  
  - Penyesuaian log untuk mencatat nilai quota yang digunakan

- **`AppServiceProvider.php`**  
  - Registrasi variable quota ke view composer

- **`_navbar.blade.php`**  
  - Tampilkan nilai quota dari env di navbar (opsional untuk monitoring)

## Environment Variables
Tambahkan di file `.env`:
